### PR TITLE
ci(update_tools): neutralize "regex characters" from version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.luau text eol=lf

--- a/.lune/update_tools.luau
+++ b/.lune/update_tools.luau
@@ -148,7 +148,7 @@ for _, binSrc in pathfs.readDir(BINS_SRC_DIR) do
 
 		local updatedManifest = string.gsub(
 			manifestContents,
-			oldField,
+			string.gsub(oldField, "[%.%+%-]", "%%%0"),
 			newField,
 			-- Only replace the first occurrence to be safe
 			1

--- a/.lune/update_tools.luau
+++ b/.lune/update_tools.luau
@@ -146,13 +146,16 @@ for _, binSrc in pathfs.readDir(BINS_SRC_DIR) do
 		-- New version field string:
 		local newField = string.gsub(serde.encode("toml", { version = stripLeadingVersion(newVersion) }), "%s+$", "")
 
-		local updatedManifest = string.gsub(
+		local updatedManifest, replaces = string.gsub(
 			manifestContents,
 			string.gsub(oldField, "[%.%+%-]", "%%%0"),
 			newField,
 			-- Only replace the first occurrence to be safe
 			1
 		)
+		if replaces == 0 then
+			error("failed to replace version field in manifest")
+		end
 
 		local toWrite = table.find(process.args, "--yes")
 			or table.find(process.args, "-y")

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,4 +3,5 @@
   "luau-lsp.require.useOriginalRequireByStringSemantics": true,
   "stylua.targetReleaseVersion": "latest",
   "editor.formatOnSave": true,
+  "files.eol": "\n"
 }


### PR DESCRIPTION
# Issue
versions like `1.0.0+rc.3` could be interpreted as regex 1(.)0(.)(0+)rc(.)3

# Importance
while i have worked on previous ci-cd for publish tools i had some problems running update_tools, so i fixed with this changes